### PR TITLE
switch back to instance alarms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 // CPU Utilization
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   count               = var.create_high_cpu_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-highCPUUtilization-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-highCPUUtilization-${var.db_instance_id}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "CPUUtilization"
@@ -14,8 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBClusterIdentifier = var.db_cluster_id
-    Role                = var.role
+    DBInstanceIdentifier = var.db_instance_id
   }
   tags = var.tags
 }
@@ -23,7 +22,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
 // Disk Utilization
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   count               = var.create_high_queue_depth_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-highDiskQueueDepth-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-highDiskQueueDepth-${var.db_instance_id}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "DiskQueueDepth"
@@ -36,15 +35,14 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBClusterIdentifier = var.db_cluster_id
-    Role                = var.role
+    DBInstanceIdentifier = var.db_instance_id
   }
   tags = var.tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_free_storage_space_too_low" {
   count               = var.create_low_disk_space_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-lowFreeStorageSpace-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-lowFreeStorageSpace-${var.db_instance_id}"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "FreeStorageSpace"
@@ -57,15 +55,14 @@ resource "aws_cloudwatch_metric_alarm" "disk_free_storage_space_too_low" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBClusterIdentifier = var.db_cluster_id
-    Role                = var.role
+    DBInstanceIdentifier = var.db_instance_id
   }
   tags = var.tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_burst_balance_too_low" {
   count               = var.create_low_disk_burst_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-lowEBSBurstBalance-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-lowEBSBurstBalance-${var.db_instance_id}"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "BurstBalance"
@@ -78,8 +75,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_burst_balance_too_low" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBClusterIdentifier = var.db_cluster_id
-    Role                = var.role
+    DBInstanceIdentifier = var.db_instance_id
   }
   tags = var.tags
 }
@@ -87,7 +83,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_burst_balance_too_low" {
 // Memory Utilization
 resource "aws_cloudwatch_metric_alarm" "memory_freeable_too_low" {
   count               = var.create_low_memory_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-lowFreeableMemory-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-lowFreeableMemory-${var.db_instance_id}"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "FreeableMemory"
@@ -100,15 +96,14 @@ resource "aws_cloudwatch_metric_alarm" "memory_freeable_too_low" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBClusterIdentifier = var.db_cluster_id
-    Role                = var.role
+    DBInstanceIdentifier = var.db_instance_id
   }
   tags = var.tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_swap_usage_too_high" {
   count               = var.create_swap_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-highSwapUsage-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-highSwapUsage-${var.db_instance_id}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "SwapUsage"
@@ -121,8 +116,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_swap_usage_too_high" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBClusterIdentifier = var.db_cluster_id
-    Role                = var.role
+    DBInstanceIdentifier = var.db_instance_id
   }
   tags = var.tags
 }
@@ -130,7 +124,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_swap_usage_too_high" {
 // Connection Count
 resource "aws_cloudwatch_metric_alarm" "connection_count_anomalous" {
   count               = var.create_anomaly_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-anomalousConnectionCount-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-anomalousConnectionCount-${var.db_instance_id}"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = var.evaluation_period
   threshold_metric_id = "e1"
@@ -156,8 +150,7 @@ resource "aws_cloudwatch_metric_alarm" "connection_count_anomalous" {
       unit        = "Count"
 
       dimensions = {
-        DBClusterIdentifier = var.db_cluster_id
-        Role                = var.role
+        DBInstanceIdentifier = var.db_instance_id
       }
     }
   }
@@ -168,7 +161,7 @@ resource "aws_cloudwatch_metric_alarm" "connection_count_anomalous" {
 // more info - https://aws.amazon.com/blogs/database/implement-an-early-warning-system-for-transaction-id-wraparound-in-amazon-rds-for-postgresql/
 resource "aws_cloudwatch_metric_alarm" "maximum_used_transaction_ids_too_high" {
   count               = contains(["aurora-postgresql", "postgres"], var.engine) ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-maximumUsedTransactionIDs-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-maximumUsedTransactionIDs-${var.db_instance_id}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "MaximumUsedTransactionIDs"
@@ -184,7 +177,7 @@ resource "aws_cloudwatch_metric_alarm" "maximum_used_transaction_ids_too_high" {
 # Read I/O
 resource "aws_cloudwatch_metric_alarm" "read_iops_is_too_high" {
   count               = var.create_read_iops_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-highReadIOPS-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-highReadIOPS-${var.db_instance_id}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "ReadIOPS"
@@ -197,8 +190,7 @@ resource "aws_cloudwatch_metric_alarm" "read_iops_is_too_high" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBClusterIdentifier = var.db_cluster_id
-    Role                = var.role
+    DBInstanceIdentifier = var.db_instance_id
   }
   tags = var.tags
 }
@@ -206,7 +198,7 @@ resource "aws_cloudwatch_metric_alarm" "read_iops_is_too_high" {
 # Free local storage space (Aurora)
 resource "aws_cloudwatch_metric_alarm" "free_local_storage_is_too_low" {
   count               = var.create_free_local_storage_alarm ? 1 : 0
-  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-lowFreeLocalStorage-${var.role}"
+  alarm_name          = "${var.prefix}rds-${var.db_cluster_id}-lowFreeLocalStorage-${var.db_instance_id}"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period
   metric_name         = "FreeLocalStorage"
@@ -219,8 +211,7 @@ resource "aws_cloudwatch_metric_alarm" "free_local_storage_is_too_low" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBClusterIdentifier = var.db_cluster_id
-    Role                = var.role
+    DBInstanceIdentifier = var.db_instance_id
   }
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "db_cluster_id" {
   description = "RDS Cluster ID"
 }
 
+variable "db_instance_id" {
+  type        = string
+  description = "RDS Instance ID"
+}
+
 variable "role" {
   type        = string
   description = "READER or WRITER role dimension to differentiate alarms for the same cluster"


### PR DESCRIPTION
monitoring the cluster by role will also catch autoscaled instances but its failing compliance checks. The reason we used the cluster level was to try to include autoscaled instances so the compliance check doesn't fail when that spins up but that's not useful since the check ALWAYS now fails since is it doesn't see the cluster level alarms.